### PR TITLE
Update playbooks to match Ansible 2.9 stable release

### DIFF
--- a/OEM_EXTENSIONS.md
+++ b/OEM_EXTENSIONS.md
@@ -8,7 +8,7 @@ This document describes an approach for extending the standard Redfish Ansible m
 
 ## The Approach
 
-With the current Redfish Ansible support, there are three main modules (`redfish_command.py`, `redfish_config.py` and `redfish_facts.py`). These three modules are relatively thin modules that establish the commands and their parameters and then call out to a utility module, `redfish_utils.py`, that has the bulk of the logic to interact with the Redfish services.
+With the current Redfish Ansible support, there are three main modules (`redfish_command.py`, `redfish_config.py` and `redfish_info.py`). These three modules are relatively thin modules that establish the commands and their parameters and then call out to a utility module, `redfish_utils.py`, that has the bulk of the logic to interact with the Redfish services.
 
 The `redfish_utils.py` module implements a `RedfishUtils` class that has many methods to perform the various Redfish operations. With this architecture, a new vendor module that needs to add a specific Oem feature can create a new class (e.g. `ContosoRedfishUtils`) that extends the existing `RedfishUtils`. New method(s) can be added to that class (or existing methods overridden) while still being able to leverage all the existing standard methods in the parent class. Then a new vendor module (e.g. `contoso_redfish_command.py`) can be written that is basically a sparse version of `redfish_command.py` that only needs to handle the new or changed vendor commands.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository contains a set of example Ansible playbooks for invoking the Red
 
 ## Prerequisites
 
-To use these playbooks, you first need to install Ansible (version 2.7 or later; preferably version 2.8 or later). The Redfish Ansible modules are included in the Ansible distribution. Instructions for installing Ansible can be found here:
+To use these playbooks, you first need to install the latest stable release of Ansible (currently version 2.9). The Redfish Ansible modules are included in the Ansible distribution. Instructions for installing Ansible can be found here:
 
 [Ansible Installation Guide](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html)
 

--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ The three Redfish modules are summarized here:
 
 	The `redfish_config` module performs OOB controller operations like setting the BIOS configuration.
 
-3. [redfish_facts](https://docs.ansible.com/ansible/latest/modules/redfish_facts_module.html) (source: [redfish_facts.py](https://github.com/ansible/ansible/blob/devel/lib/ansible/modules/remote_management/redfish/redfish_facts.py))
+3. [redfish_info](https://docs.ansible.com/ansible/devel/modules/redfish_info_module.html) (source: [redfish_info.py](https://github.com/ansible/ansible/blob/devel/lib/ansible/modules/remote_management/redfish/redfish_info.py))
 
-	The `redfish_facts` module retrieves information about the OOB controller like Systems inventory and Accounts inventory.
+	The `redfish_info` module retrieves information about the OOB controller like Systems inventory and Accounts inventory.
 
 All three of the above modules use this utility module: [redfish_utils.py](https://github.com/ansible/ansible/blob/devel/lib/ansible/module_utils/redfish_utils.py)
 

--- a/playbooks/accounts/list_users.yml
+++ b/playbooks/accounts/list_users.yml
@@ -13,7 +13,7 @@
     include_tasks: create_output_file.yml
 
   - name: List all users
-    redfish_facts:
+    redfish_info:
       category: Accounts
       command: ListUsers
       baseuri: "{{ baseuri }}"

--- a/playbooks/chassis/get_chassis_inventory.yml
+++ b/playbooks/chassis/get_chassis_inventory.yml
@@ -13,7 +13,7 @@
     include_tasks: create_output_file.yml
 
   - name: Get chassis Inventory
-    redfish_facts:
+    redfish_info:
       category: Chassis
       command: GetChassisInventory
       baseuri: "{{ baseuri }}"

--- a/playbooks/chassis/get_chassis_power.yml
+++ b/playbooks/chassis/get_chassis_power.yml
@@ -13,7 +13,7 @@
     include_tasks: create_output_file.yml
 
   - name: Get chassis power
-    redfish_facts:
+    redfish_info:
       category: Chassis
       command: GetChassisPower
       baseuri: "{{ baseuri }}"

--- a/playbooks/chassis/get_chassis_thermals.yml
+++ b/playbooks/chassis/get_chassis_thermals.yml
@@ -13,7 +13,7 @@
     include_tasks: create_output_file.yml
 
   - name: Get chassis thermals
-    redfish_facts:
+    redfish_info:
       category: Chassis
       command: GetChassisThermals
       baseuri: "{{ baseuri }}"

--- a/playbooks/chassis/get_fan_inventory.yml
+++ b/playbooks/chassis/get_fan_inventory.yml
@@ -13,7 +13,7 @@
     include_tasks: create_output_file.yml
 
   - name: Get fans statistics
-    redfish_facts:
+    redfish_info:
       category: Chassis
       command: GetFanInventory
       baseuri: "{{ baseuri }}"

--- a/playbooks/chassis/get_psu_inventory.yml
+++ b/playbooks/chassis/get_psu_inventory.yml
@@ -13,7 +13,7 @@
     include_tasks: create_output_file.yml
 
   - name: Get PSU Inventory
-    redfish_facts:
+    redfish_info:
       category: Chassis
       command: GetPsuInventory
       baseuri: "{{ baseuri }}"

--- a/playbooks/manager/get_manager_logs.yml
+++ b/playbooks/manager/get_manager_logs.yml
@@ -13,7 +13,7 @@
     include_tasks: create_output_file.yml
 
   - name: Get Manager Logs
-    redfish_facts:
+    redfish_info:
       category: Manager
       command: GetLogs
       baseuri: "{{ baseuri }}"

--- a/playbooks/manager/get_manager_nic_inventory.yml
+++ b/playbooks/manager/get_manager_nic_inventory.yml
@@ -13,7 +13,7 @@
     include_tasks: create_output_file.yml
 
   - name: Get Manager NIC inventory
-    redfish_facts:
+    redfish_info:
       category: Manager
       command: GetManagerNicInventory
       baseuri: "{{ baseuri }}"

--- a/playbooks/manager/get_virtual_media.yml
+++ b/playbooks/manager/get_virtual_media.yml
@@ -1,0 +1,27 @@
+---
+- hosts: myhosts
+  connection: local
+  name: Manager virtual media
+  gather_facts: False
+
+  vars:
+    datatype: VirtualMedia
+
+  tasks:
+
+  - name: Set output file
+    include_tasks: create_output_file.yml
+
+  - name: Get Virtual Media information
+    redfish_info:
+      category: Manager
+      command: GetVirtualMedia
+      baseuri: "{{ baseuri }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+    register: result
+
+  - name: Copy results to output file
+    copy:
+      content: "{{ result | to_nice_json }}"
+      dest: "{{ template }}.json"

--- a/playbooks/sessions/get_session_information.yml
+++ b/playbooks/sessions/get_session_information.yml
@@ -1,0 +1,27 @@
+---
+- hosts: myhosts
+  connection: local
+  name: Sessions
+  gather_facts: False
+
+  vars:
+    datatype: Sessions
+
+  tasks:
+
+  - name: Set output file
+    include_tasks: create_output_file.yml
+
+  - name: Get sessions
+    redfish_info:
+      category: Sessions
+      command: GetSessions
+      baseuri: "{{ baseuri }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+    register: result
+
+  - name: Copy results to output file
+    copy:
+      content: "{{ result | to_nice_json }}"
+      dest: "{{ template }}.json"

--- a/playbooks/systems/get_bios_attributes.yml
+++ b/playbooks/systems/get_bios_attributes.yml
@@ -13,7 +13,7 @@
     include_tasks: create_output_file.yml
 
   - name: Get BIOS attributes
-    redfish_facts:
+    redfish_info:
       category: Systems
       command: GetBiosAttributes
       baseuri: "{{ baseuri }}"

--- a/playbooks/systems/get_boot_order.yml
+++ b/playbooks/systems/get_boot_order.yml
@@ -13,7 +13,7 @@
     include_tasks: create_output_file.yml
 
   - name: Get device boot order
-    redfish_facts:
+    redfish_info:
       category: Systems
       command: GetBootOrder
       baseuri: "{{ baseuri }}"

--- a/playbooks/systems/get_boot_override.yml
+++ b/playbooks/systems/get_boot_override.yml
@@ -13,7 +13,7 @@
     include_tasks: create_output_file.yml
 
   - name: Get Boot Override information
-    redfish_facts:
+    redfish_info:
       category: Systems
       command: GetBootOverride
       baseuri: "{{ baseuri }}"

--- a/playbooks/systems/get_cpu_inventory.yml
+++ b/playbooks/systems/get_cpu_inventory.yml
@@ -13,7 +13,7 @@
     include_tasks: create_output_file.yml
 
   - name: Get CPU Inventory
-    redfish_facts:
+    redfish_info:
       category: Systems
       command: GetCpuInventory
       baseuri: "{{ baseuri }}"

--- a/playbooks/systems/get_disk_inventory.yml
+++ b/playbooks/systems/get_disk_inventory.yml
@@ -13,7 +13,7 @@
     include_tasks: create_output_file.yml
 
   - name: Get drive inventory
-    redfish_facts:
+    redfish_info:
       category: Systems
       command: GetDiskInventory
       baseuri: "{{ baseuri }}"

--- a/playbooks/systems/get_memory_inventory.yml
+++ b/playbooks/systems/get_memory_inventory.yml
@@ -13,7 +13,7 @@
     include_tasks: create_output_file.yml
 
   - name: Get memory inventory
-    redfish_facts:
+    redfish_info:
       category: Systems
       command: GetMemoryInventory
       baseuri: "{{ baseuri }}"

--- a/playbooks/systems/get_nic_inventory.yml
+++ b/playbooks/systems/get_nic_inventory.yml
@@ -13,7 +13,7 @@
     include_tasks: create_output_file.yml
 
   - name: Get NIC Information
-    redfish_facts:
+    redfish_info:
       category: Systems
       command: GetNicInventory
       baseuri: "{{ baseuri }}"

--- a/playbooks/systems/get_storage_cont_inventory.yml
+++ b/playbooks/systems/get_storage_cont_inventory.yml
@@ -13,7 +13,7 @@
     include_tasks: create_output_file.yml
 
   - name: Get storage controller inventory
-    redfish_facts:
+    redfish_info:
       category: Systems
       command: GetStorageControllerInventory
       baseuri: "{{ baseuri }}"

--- a/playbooks/systems/get_system_inventory.yml
+++ b/playbooks/systems/get_system_inventory.yml
@@ -13,7 +13,7 @@
     include_tasks: create_output_file.yml
 
   - name: Getting system inventory
-    redfish_facts:
+    redfish_info:
       category: Systems
       command: GetSystemInventory
       baseuri: "{{ baseuri }}"

--- a/playbooks/systems/get_system_inventory_all.yml
+++ b/playbooks/systems/get_system_inventory_all.yml
@@ -13,7 +13,7 @@
     include_tasks: create_output_file.yml
 
   - name: Get Inventory
-    redfish_facts:
+    redfish_info:
       category: Systems
       command: all 
       baseuri: "{{ baseuri }}"

--- a/playbooks/systems/get_system_inventory_default.yml
+++ b/playbooks/systems/get_system_inventory_default.yml
@@ -13,7 +13,7 @@
     include_tasks: create_output_file.yml
 
   - name: Get Inventory
-    redfish_facts:
+    redfish_info:
       category: Systems
       baseuri: "{{ baseuri }}"
       username: "{{ username}}"

--- a/playbooks/systems/get_system_inventory_several.yml
+++ b/playbooks/systems/get_system_inventory_several.yml
@@ -13,7 +13,7 @@
     include_tasks: create_output_file.yml
 
   - name: Get Inventory
-    redfish_facts:
+    redfish_info:
       category: Systems
       command: GetDiskInventory,GetNicInventory
       baseuri: "{{ baseuri }}"

--- a/playbooks/systems/get_volume_inventory.yml
+++ b/playbooks/systems/get_volume_inventory.yml
@@ -1,0 +1,27 @@
+---
+- hosts: myhosts
+  connection: local
+  name: Volume Inventory
+  gather_facts: False
+
+  vars:
+    datatype: VolumeInventory
+
+  tasks:
+
+  - name: Define output file
+    include_tasks: create_output_file.yml
+
+  - name: Get Volume Inventory
+    redfish_info:
+      category: Systems
+      command: GetVolumeInventory
+      baseuri: "{{ baseuri }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+    register: result
+
+  - name: Copy results to output file
+    copy:
+      content: "{{ result | to_nice_json }}"
+      dest: "{{ template }}.json"

--- a/playbooks/systems/power_force_restart.yml
+++ b/playbooks/systems/power_force_restart.yml
@@ -1,0 +1,15 @@
+---
+- hosts: myhosts
+  connection: local
+  name: Manage System Power - Force restart
+  gather_facts: False
+
+  tasks:
+
+  - name: Restart system power forcefully
+    redfish_command:
+      category: Systems
+      command: PowerForceRestart
+      baseuri: "{{ baseuri }}"
+      username: "{{ username }}"
+      password: "{{ password }}"

--- a/playbooks/update/get_firmware_inventory.yml
+++ b/playbooks/update/get_firmware_inventory.yml
@@ -13,7 +13,7 @@
     include_tasks: create_output_file.yml
 
   - name: Get Firmware Inventory
-    redfish_facts:
+    redfish_info:
       category: Update
       command: GetFirmwareInventory
       baseuri: "{{ baseuri }}"

--- a/playbooks/update/get_firmware_update_methods.yml
+++ b/playbooks/update/get_firmware_update_methods.yml
@@ -13,7 +13,7 @@
     include_tasks: create_output_file.yml
 
   - name: Get Firmware Update Capabilities
-    redfish_facts:
+    redfish_info:
       category: Update
       command: GetFirmwareUpdateCapabilities
       baseuri: "{{ baseuri }}"


### PR DESCRIPTION
Updates:

- change module name from redfish_facts to redfish_info
- add power_force_restart.yml playbook
- add get_session_information.yml playbook
- add get_volume_inventory.yml playbook
- add get_virtual_media.yml playbook