### PR TITLE
Update playbooks in devel branch with new features

### DIFF
--- a/inventory.yml
+++ b/inventory.yml
@@ -21,9 +21,3 @@ rootdir=~/inventory_files
 # Shorter name for inventory_hostname
 # Refers to the logical inventory hostname (example: redfish1)
 host="{{inventory_hostname}}"
-
-# Vars for managing accounts
-id=3
-new_username=user3
-new_password=B1g$3cr3t
-roleid=Operator

--- a/playbooks/accounts/add_user.yml
+++ b/playbooks/accounts/add_user.yml
@@ -4,6 +4,11 @@
   name: Add User
   gather_facts: False
 
+  vars:
+  - account_username: user1
+  - account_password: B1g$3cr3t
+  - account_roleid: Operator
+
   tasks:
 
   # When adding a user, it must be enabled afterwards
@@ -14,7 +19,6 @@
       baseuri: "{{ baseuri }}"
       username: "{{ username }}"
       password: "{{ password }}"
-      id: "{{ id }}"
-      new_username: "{{ new_username }}"
-      new_password: "{{ new_password }}"
-      roleid: "{{ roleid }}"
+      account_username: "{{ account_username }}"
+      account_password: "{{ account_password }}"
+      account_roleid: "{{ account_roleid }}"

--- a/playbooks/accounts/delete_user.yml
+++ b/playbooks/accounts/delete_user.yml
@@ -4,6 +4,9 @@
   name: Delete User
   gather_facts: False
 
+  vars:
+  - account_username: user1
+
   tasks:
 
   - name: Delete user
@@ -13,4 +16,4 @@
       baseuri: "{{ baseuri }}"
       username: "{{ username }}"
       password: "{{ password }}"
-      id: "{{ id }}"
+      account_username: "{{ account_username }}"

--- a/playbooks/accounts/disable_user.yml
+++ b/playbooks/accounts/disable_user.yml
@@ -4,6 +4,9 @@
   name: Disable User
   gather_facts: False
 
+  vars:
+  - account_username: user1
+
   tasks:
 
   - name: Disable user
@@ -13,4 +16,4 @@
       baseuri: "{{ baseuri }}"
       username: "{{ username }}"
       password: "{{ password }}"
-      id: "{{ id }}"
+      account_username: "{{ account_username }}"

--- a/playbooks/accounts/enable_user.yml
+++ b/playbooks/accounts/enable_user.yml
@@ -4,6 +4,9 @@
   name: Enable User
   gather_facts: False
 
+  vars:
+  - account_username: user1
+
   tasks:
 
   - name: Enable user
@@ -13,4 +16,4 @@
       baseuri: "{{ baseuri }}"
       username: "{{ username }}"
       password: "{{ password }}"
-      id: "{{ id }}"
+      account_username: "{{ account_username }}"

--- a/playbooks/accounts/update_account_props.yml
+++ b/playbooks/accounts/update_account_props.yml
@@ -1,0 +1,21 @@
+---
+- hosts: myhosts
+  connection: local
+  name: Update Account Service Properties
+  gather_facts: False
+
+  vars:
+  - account_properties:
+      AccountLockoutThreshold: 5
+      AccountLockoutDuration: 600
+
+  tasks:
+
+  - name: Update Account Service Properties
+    redfish_command:
+      category: Accounts
+      command: UpdateAccountServiceProperties
+      baseuri: "{{ baseuri }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+      account_properties: "{{ account_properties }}"

--- a/playbooks/accounts/update_user_name.yml
+++ b/playbooks/accounts/update_user_name.yml
@@ -1,0 +1,21 @@
+---
+- hosts: myhosts
+  connection: local
+  name: Update user name
+  gather_facts: False
+
+  vars:
+  - account_username: alice
+  - update_username: carol
+
+  tasks:
+
+  - name: Update user name from {{ account_username }} to {{ update_username }}
+    redfish_command:
+      category: Accounts
+      command: UpdateUserName
+      baseuri: "{{ baseuri }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+      account_username: "{{ account_username }}"
+      update_username: "{{ update_username }}"

--- a/playbooks/accounts/update_user_password.yml
+++ b/playbooks/accounts/update_user_password.yml
@@ -4,6 +4,10 @@
   name: Update user password
   gather_facts: False
 
+  vars:
+  - account_username: user1
+  - account_password: M0re$3cr3t
+
   tasks:
 
   - name: Update user password
@@ -13,5 +17,5 @@
       baseuri: "{{ baseuri }}"
       username: "{{ username }}"
       password: "{{ password }}"
-      id: "{{ id }}"
-      new_password: "{{ new_password }}"
+      account_username: "{{ account_username }}"
+      account_password: "{{ account_password }}"

--- a/playbooks/accounts/update_user_role.yml
+++ b/playbooks/accounts/update_user_role.yml
@@ -4,6 +4,10 @@
   name: Update user role
   gather_facts: False
 
+  vars:
+  - account_username: user1
+  - account_roleid: ReadOnly
+
   tasks:
 
   - name: Update user role
@@ -13,5 +17,5 @@
       baseuri: "{{ baseuri }}"
       username: "{{ username }}"
       password: "{{ password }}"
-      id: "{{ id }}"
-      roleid: "{{ roleid }}"
+      account_username: "{{ account_username }}"
+      account_roleid: "{{ account_roleid }}"

--- a/playbooks/chassis/get_chassis_health.yml
+++ b/playbooks/chassis/get_chassis_health.yml
@@ -1,0 +1,27 @@
+---
+- hosts: myhosts
+  connection: local
+  name: Chassis Health Report
+  gather_facts: False
+
+  vars:
+    datatype: ChassisHealth
+
+  tasks:
+
+  - name: Define output file
+    include_tasks: create_output_file.yml
+
+  - name: Getting chassis health report
+    redfish_facts:
+      category: Chassis
+      command: GetHealthReport
+      baseuri: "{{ baseuri }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+    register: result
+
+  - name: Copy results to output file
+    copy:
+      content: "{{ result | to_nice_json }}"
+      dest: "{{ template }}.json"

--- a/playbooks/chassis/indicator_led_blink.yml
+++ b/playbooks/chassis/indicator_led_blink.yml
@@ -10,6 +10,7 @@
     redfish_command:
       category: Chassis
       command: IndicatorLedBlink
+      resource_id: 1U
       baseuri: "{{ baseuri }}"
       username: "{{ username}}"
       password: "{{ password }}"

--- a/playbooks/chassis/indicator_led_off.yml
+++ b/playbooks/chassis/indicator_led_off.yml
@@ -10,6 +10,7 @@
     redfish_command:
       category: Chassis
       command: IndicatorLedOff
+      resource_id: 1U
       baseuri: "{{ baseuri }}"
       username: "{{ username}}"
       password: "{{ password }}"

--- a/playbooks/chassis/indicator_led_on.yml
+++ b/playbooks/chassis/indicator_led_on.yml
@@ -10,6 +10,7 @@
     redfish_command:
       category: Chassis
       command: IndicatorLedOn
+      resource_id: 1U
       baseuri: "{{ baseuri }}"
       username: "{{ username}}"
       password: "{{ password }}"

--- a/playbooks/manager/clear_logs.yml
+++ b/playbooks/manager/clear_logs.yml
@@ -10,6 +10,7 @@
     redfish_command:
       category: Manager
       command: ClearLogs
+      resource_id: BMC
       baseuri: "{{ baseuri }}"
       username: "{{ username }}"
       password: "{{ password }}"

--- a/playbooks/manager/get_manager_health.yml
+++ b/playbooks/manager/get_manager_health.yml
@@ -1,0 +1,27 @@
+---
+- hosts: myhosts
+  connection: local
+  name: Manager Health Report
+  gather_facts: False
+
+  vars:
+    datatype: ManagerHealth
+
+  tasks:
+
+  - name: Define output file
+    include_tasks: create_output_file.yml
+
+  - name: Getting manager health report
+    redfish_facts:
+      category: Manager
+      command: GetHealthReport
+      baseuri: "{{ baseuri }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+    register: result
+
+  - name: Copy results to output file
+    copy:
+      content: "{{ result | to_nice_json }}"
+      dest: "{{ template }}.json"

--- a/playbooks/manager/get_network_protocols.yml
+++ b/playbooks/manager/get_network_protocols.yml
@@ -1,0 +1,27 @@
+---
+- hosts: myhosts
+  connection: local
+  name: Get Manager Network Protocols
+  gather_facts: False
+
+  vars:
+    datatype: ManagerNetworkProtocols
+
+  tasks:
+
+  - name: Set output file
+    include_tasks: create_output_file.yml
+
+  - name: Get Manager Network Protocols
+    redfish_info:
+      category: Manager
+      command: GetNetworkProtocols
+      baseuri: "{{ baseuri }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+    register: result
+
+  - name: Copy results to output file
+    copy:
+      content: "{{ result | to_nice_json }}"
+      dest: "{{ template }}.json"

--- a/playbooks/manager/restart_manager.yml
+++ b/playbooks/manager/restart_manager.yml
@@ -10,6 +10,7 @@
     redfish_command:
       category: Manager
       command: GracefulRestart
+      resource_id: BMC
       baseuri: "{{ baseuri }}"
       username: "{{ username }}"
       password: "{{ password }}"

--- a/playbooks/manager/set_manager_nic.yml
+++ b/playbooks/manager/set_manager_nic.yml
@@ -1,0 +1,23 @@
+---
+- hosts: myhosts
+  connection: local
+  name: Set Manager NIC
+  gather_facts: False
+
+  tasks:
+
+  - name: Set Manager NIC
+    redfish_config:
+      category: Manager
+      command: SetManagerNic
+      nic_addr: 192.168.0.10
+      nic_config:
+        IPv4Addresses:
+          Address: 192.168.1.3
+          Gateway: 192.168.1.1
+          SubnetMask: 255.255.255.0
+      resource_id: BMC
+      baseuri: "{{ baseuri }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+    register: result

--- a/playbooks/manager/set_network_protocols.yml
+++ b/playbooks/manager/set_network_protocols.yml
@@ -1,0 +1,24 @@
+---
+- hosts: myhosts
+  connection: local
+  name: Set Manager Network Protocols
+  gather_facts: False
+
+  tasks:
+
+  - name: Set Manager Network Protocols
+    redfish_config:
+      category: Manager
+      command: SetNetworkProtocols
+      network_protocols:
+        SNMP:
+          ProtocolEnabled: True
+          port: 161
+        HTTP:
+          ProtocolEnabled: False
+          port: 8080
+      resource_id: BMC
+      baseuri: "{{ baseuri }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+    register: result

--- a/playbooks/systems/get_system_health.yml
+++ b/playbooks/systems/get_system_health.yml
@@ -1,0 +1,27 @@
+---
+- hosts: myhosts
+  connection: local
+  name: System Health Report
+  gather_facts: False
+
+  vars:
+    datatype: SystemHealth
+
+  tasks:
+
+  - name: Define output file
+    include_tasks: create_output_file.yml
+
+  - name: Getting system health report
+    redfish_facts:
+      category: Systems
+      command: GetHealthReport
+      baseuri: "{{ baseuri }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+    register: result
+
+  - name: Copy results to output file
+    copy:
+      content: "{{ result | to_nice_json }}"
+      dest: "{{ template }}.json"

--- a/playbooks/systems/power_force_off.yml
+++ b/playbooks/systems/power_force_off.yml
@@ -10,6 +10,7 @@
     redfish_command:
       category: Systems
       command: PowerForceOff
+      resource_id: 437XR1138R2
       baseuri: "{{ baseuri }}"
       username: "{{ username }}"
       password: "{{ password }}"

--- a/playbooks/systems/power_graceful_restart.yml
+++ b/playbooks/systems/power_graceful_restart.yml
@@ -10,6 +10,7 @@
     redfish_command:
       category: Systems
       command: PowerGracefulRestart
+      resource_id: 437XR1138R2
       baseuri: "{{ baseuri }}"
       username: "{{ username }}"
       password: "{{ password }}"

--- a/playbooks/systems/power_graceful_shutdown.yml
+++ b/playbooks/systems/power_graceful_shutdown.yml
@@ -10,6 +10,7 @@
     redfish_command:
       category: Systems
       command: PowerGracefulShutdown
+      resource_id: 437XR1138R2
       baseuri: "{{ baseuri }}"
       username: "{{ username }}"
       password: "{{ password }}"

--- a/playbooks/systems/power_on.yml
+++ b/playbooks/systems/power_on.yml
@@ -10,6 +10,7 @@
     redfish_command:
       category: Systems
       command: PowerOn
+      resource_id: 437XR1138R2
       baseuri: "{{ baseuri }}"
       username: "{{ username }}"
       password: "{{ password }}"

--- a/playbooks/systems/power_reboot.yml
+++ b/playbooks/systems/power_reboot.yml
@@ -10,6 +10,7 @@
     redfish_command:
       category: Systems
       command: PowerReboot
+      resource_id: 437XR1138R2
       baseuri: "{{ baseuri }}"
       username: "{{ username }}"
       password: "{{ password }}"

--- a/playbooks/systems/set_bios_attribute.yml
+++ b/playbooks/systems/set_bios_attribute.yml
@@ -14,6 +14,7 @@
   # SriovGlobalEnable     Disabled / Enabled
 
   vars:
+  - system_id: 437XR1138R2
   - attributes:
       SriovGlobalEnable: Enabled
       ProcVirtualization: Disabled
@@ -24,6 +25,7 @@
     redfish_config:
       category: Systems
       command: SetBiosAttributes
+      resource_id: "{{ system_id }}"
       bios_attributes: "{{ attributes }}"
       baseuri: "{{ baseuri }}"
       username: "{{ username }}"
@@ -34,6 +36,7 @@
     redfish_command:
       category: Systems
       command: PowerReboot
+      resource_id: "{{ system_id }}"
       baseuri: "{{ baseuri }}"
       username: "{{ username }}"
       password: "{{ password }}"

--- a/playbooks/systems/set_bios_attribute.yml
+++ b/playbooks/systems/set_bios_attribute.yml
@@ -14,8 +14,9 @@
   # SriovGlobalEnable     Disabled / Enabled
 
   vars:
-  - attribute_name: SriovGlobalEnable
-  - attribute_value: Enabled
+  - attributes:
+      SriovGlobalEnable: Enabled
+      ProcVirtualization: Disabled
 
   tasks:
 
@@ -23,8 +24,7 @@
     redfish_config:
       category: Systems
       command: SetBiosAttributes
-      bios_attribute_name: "{{ attribute_name }}"
-      bios_attribute_value: "{{ attribute_value }}"
+      bios_attributes: "{{ attributes }}"
       baseuri: "{{ baseuri }}"
       username: "{{ username }}"
       password: "{{ password }}"

--- a/playbooks/systems/set_boot_order.yml
+++ b/playbooks/systems/set_boot_order.yml
@@ -1,0 +1,26 @@
+---
+- hosts: myhosts
+  connection: local
+  name: Set boot order
+  gather_facts: False
+
+  vars:
+  - boot_order:
+    - "Boot0004"
+    - "Boot0003"
+    - "Boot0002"
+    - "Boot0001"
+    - "Boot0000"
+
+  tasks:
+
+  - name: Set boot order to {{ boot_order }}
+    redfish_config:
+      category: Systems
+      command: SetBootOrder
+      resource_id: "1"
+      boot_order: "{{ boot_order }}"
+      baseuri: "{{ baseuri }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+    register: result

--- a/playbooks/systems/set_default_bios_settings.yml
+++ b/playbooks/systems/set_default_bios_settings.yml
@@ -4,12 +4,16 @@
   name: Set default BIOS settings
   gather_facts: False
 
+  vars:
+  - system_id: 437XR1138R2
+
   tasks:
 
   - name: Set BIOS default settings
     redfish_config:
       category: Systems
       command: SetBiosDefaultSettings
+      resource_id: "{{ system_id }}"
       baseuri: "{{ baseuri }}"
       username: "{{ username }}"
       password: "{{ password }}"
@@ -19,6 +23,7 @@
     redfish_command:
       category: Systems
       command: PowerReboot
+      resource_id: "{{ system_id }}"
       baseuri: "{{ baseuri }}"
       username: "{{ username }}"
       password: "{{ password }}"

--- a/playbooks/systems/set_default_boot_order.yml
+++ b/playbooks/systems/set_default_boot_order.yml
@@ -1,0 +1,17 @@
+---
+- hosts: myhosts
+  connection: local
+  name: Set default boot order
+  gather_facts: False
+
+  tasks:
+
+  - name: Set boot order to default
+    redfish_config:
+      category: Systems
+      command: SetDefaultBootOrder
+      resource_id: "1"
+      baseuri: "{{ baseuri }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+    register: result

--- a/playbooks/systems/set_onetime_boot_legacy.yml
+++ b/playbooks/systems/set_onetime_boot_legacy.yml
@@ -8,6 +8,7 @@
   # Usb, Utilities, Diags, UefiShell, and SDCard.
 
   vars:
+    - system_id: 437XR1138R2
     - bootdevice: Pxe
 
   tasks:
@@ -16,6 +17,7 @@
     redfish_command:
       category: Systems
       command: SetOneTimeBoot
+      resource_id: "{{ system_id }}"
       bootdevice: "{{ bootdevice }}"
       baseuri: "{{ baseuri }}"
       username: "{{ username }}"
@@ -26,6 +28,7 @@
     redfish_command:
       category: Systems
       command: PowerReboot
+      resource_id: "{{ system_id }}"
       baseuri: "{{ baseuri }}"
       username: "{{ username }}"
       password: "{{ password }}"

--- a/playbooks/systems/set_onetime_boot_next.yml
+++ b/playbooks/systems/set_onetime_boot_next.yml
@@ -5,6 +5,7 @@
   gather_facts: False
 
   vars:
+    - system_id: 437XR1138R2
     - bootdevice: UefiBootNext
     - boot_next: Boot0001
 
@@ -14,6 +15,7 @@
     redfish_command:
       category: Systems
       command: SetOneTimeBoot
+      resource_id: "{{ system_id }}"
       bootdevice: "{{ bootdevice }}"
       boot_next: "{{ boot_next }}"
       baseuri: "{{ baseuri }}"
@@ -25,6 +27,7 @@
     redfish_command:
       category: Systems
       command: PowerReboot
+      resource_id: "{{ system_id }}"
       baseuri: "{{ baseuri }}"
       username: "{{ username }}"
       password: "{{ password }}"

--- a/playbooks/systems/set_onetime_boot_uefi.yml
+++ b/playbooks/systems/set_onetime_boot_uefi.yml
@@ -5,6 +5,7 @@
   gather_facts: False
 
   vars:
+    - system_id: 437XR1138R2
     - bootdevice: UefiTarget
     - uefi_target: "/0x31/0x33/0x01/0x01"
 
@@ -14,6 +15,7 @@
     redfish_command:
       category: Systems
       command: SetOneTimeBoot
+      resource_id: "{{ system_id }}"
       bootdevice: "{{ bootdevice }}"
       uefi_target: "{{ uefi_target }}"
       baseuri: "{{ baseuri }}"
@@ -25,6 +27,7 @@
     redfish_command:
       category: Systems
       command: PowerReboot
+      resource_id: "{{ system_id }}"
       baseuri: "{{ baseuri }}"
       username: "{{ username }}"
       password: "{{ password }}"

--- a/playbooks/update/get_software_inventory.yml
+++ b/playbooks/update/get_software_inventory.yml
@@ -1,0 +1,27 @@
+---
+- hosts: myhosts
+  connection: local
+  name: Software Inventory
+  gather_facts: False
+
+  vars:
+    datatype: SoftwareInventory
+
+  tasks:
+
+  - name: Set output file
+    include_tasks: create_output_file.yml
+
+  - name: Get Software Inventory
+    redfish_info:
+      category: Update
+      command: GetSoftwareInventory
+      baseuri: "{{ baseuri }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+    register: result
+
+  - name: Copy results to output file
+    copy:
+      content: "{{ result | to_nice_json }}"
+      dest: "{{ template }}.json"


### PR DESCRIPTION
Add new features targeted for Ansible release 2.10 to `devel` branch:

- add playbook for SetManagerNic command
- add playbooks for UpdateUserName and UpdateAccountServiceProperties
- add playbooks for GetNetworkProtocols and SetNetworkProtocols
- add playbooks for SetBootOrder and SetDefaultBootOrder
- update to specify resource_id for data modification commands
- add get_software_inventory playbook
- playbook update to set multiple BIOS attrs at once
- add health report playbooks
- feature updates to account management playbooks

Fixes #6 