### PR TITLE
Update README to refer to Ansible 2.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ This repository contains a set of example Ansible playbooks for invoking the Red
 
 ## Prerequisites
 
-To use these playbooks, you first need to install the latest stable release of Ansible (currently version 2.9). The Redfish Ansible modules are included in the Ansible distribution. Instructions for installing Ansible can be found here:
+To use these playbooks, you first need to install the 2.10 or later release of Ansible. The Redfish Ansible modules are included in the Ansible distribution. Instructions for installing Ansible can be found here:
 
-[Ansible Installation Guide](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html)
+[Ansible Installation Guide](https://docs.ansible.com/ansible/2.10/installation_guide/intro_installation.html)
 
 ## Release process
 
-The playbooks in the `master` branch of this repository are designed to work with the [latest stable release of Ansible](https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html). The playbooks in the `devel` branch can have new and modified playbooks that reflect new features in the [Ansible devel branch](https://github.com/ansible/ansible/tree/devel).
+The playbooks in the `2.9` branch of this repository are designed to work with the [latest stable 2.9 release of Ansible](https://docs.ansible.com/ansible/2.9/reference_appendices/release_and_maintenance.html). The playbooks in the `master` branch of this repository are designed to work with the [2.10 or later  Ansible release](https://docs.ansible.com/ansible/2.10/reference_appendices/release_and_maintenance.html).
 
 ## Running the playbooks
 
@@ -28,28 +28,28 @@ ansible-playbook -i inventory.yml playbooks/systems/get_system_inventory.yml
 
 ## Redfish Ansible modules
 
-The Redfish Ansible modules are maintained in the main [Ansible GitHub repository](https://github.com/ansible/ansible).
+The Redfish Ansible modules are maintained in the main [Ansible Collections community.general GitHub repository](https://github.com/ansible-collections/community.general).
 
 The three Redfish modules are summarized here:
 
-1. [redish_command](https://docs.ansible.com/ansible/latest/modules/redfish_command_module.html) (source: [redish_command.py](https://github.com/ansible/ansible/blob/devel/lib/ansible/modules/remote_management/redfish/redfish_command.py))
+1. [redfish_command](https://docs.ansible.com/ansible/2.10/collections/community/general/redfish_command_module.html) (source: [redfish_command.py](https://github.com/ansible-collections/community.general/blob/main/plugins/modules/remote_management/redfish/redfish_command.py))
 
 	The `redfish_command` module performs Out-Of-Band (OOB) controller operations like log management, adding/deleting/modifying users, and power operations (e.g. on, off, reboot, etc.).
 
-2. [redfish_config](https://docs.ansible.com/ansible/latest/modules/redfish_config_module.html) (source: [redfish_config.py](https://github.com/ansible/ansible/blob/devel/lib/ansible/modules/remote_management/redfish/redfish_config.py))
+2. [redfish_config](https://docs.ansible.com/ansible/2.10/collections/community/general/redfish_config_module.html) (source: [redfish_config.py](https://github.com/ansible-collections/community.general/blob/main/plugins/modules/remote_management/redfish/redfish_config.py))
 
 	The `redfish_config` module performs OOB controller operations like setting the BIOS configuration.
 
-3. [redfish_info](https://docs.ansible.com/ansible/devel/modules/redfish_info_module.html) (source: [redfish_info.py](https://github.com/ansible/ansible/blob/devel/lib/ansible/modules/remote_management/redfish/redfish_info.py))
+3. [redfish_info](https://docs.ansible.com/ansible/2.10/collections/community/general/redfish_info_module.html) (source: [redfish_info.py](https://github.com/ansible-collections/community.general/blob/main/plugins/modules/remote_management/redfish/redfish_info.py))
 
 	The `redfish_info` module retrieves information about the OOB controller like Systems inventory and Accounts inventory.
 
-All three of the above modules use this utility module: [redfish_utils.py](https://github.com/ansible/ansible/blob/devel/lib/ansible/module_utils/redfish_utils.py)
+All three of the above modules use this utility module: [redfish_utils.py](https://github.com/ansible-collections/community.general/blob/main/plugins/module_utils/redfish_utils.py)
 
 
 ## Contributing
 
-For the Redfish Ansible modules: File issues or submit pull requests in the [Ansible repo](https://github.com/ansible/ansible) following the [Ansible Community Guide](https://docs.ansible.com/ansible/latest/community/index.html).
+For the Redfish Ansible modules: File issues or submit pull requests in the [Ansible Collections community.general repo](https://github.com/ansible-collections/community.general) following the [Ansible Community Guide](https://docs.ansible.com/ansible/latest/community/index.html) and the [developer guide for collections](https://docs.ansible.com/ansible/devel/dev_guide/developing_collections.html#contributing-to-collections).
 
 For the Redfish Ansible playbooks: File issues or submit pull requests in this github repository.
 


### PR DESCRIPTION
Updating the README in the devel branch to refer to Ansible 2.10 and ansible-collections/community.general links. The playbooks in this branch work with the Redfish modules in Ansible 2.10 and later.

After this PR is merged, my suggestion is to create a `2.9` branch (and possible release and/or tag) from the current master branch. And then "promote" the current `devel` branch to `master`. That way, the 2.9 branch is available for use and fixes if needed. But we should encourage users to take advantage of the newer/better features in the modules based on Ansible 2.10 and later (via the `master` branch).